### PR TITLE
build multiple platform images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ bin/
 cmd/api/api
 cmd/web/web
 cmd/crawler/crawler
-cmd/testram/testram
 cmd/testcpu/testcpu
-crawler-db/
+cmd/testram/testram
 db.json
+crawler-db/
+*-linux-arm64
+*-linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,16 @@ all: build
 deploy: buildprod builddocker pushdocker
 
 buildprod:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/web/web ./cmd/web
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/api/api ./cmd/api
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/crawler/crawler ./cmd/crawler
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/testcpu/testcpu ./cmd/testcpu
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/testram/testram ./cmd/testram
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/web/web-linux-amd64 ./cmd/web
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./cmd/web/web-linux-arm64 ./cmd/web
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/api/api-linux-amd64 ./cmd/api
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./cmd/api/api-linux-arm64 ./cmd/api
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/crawler/crawler-linux-amd64 ./cmd/crawler
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./cmd/crawler/crawler-linux-arm64 ./cmd/crawler
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/testcpu/testcpu-linux-amd64 ./cmd/testcpu
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./cmd/testcpu/testcpu-linux-arm64 ./cmd/testcpu
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./cmd/testram/testram-linux-amd64 ./cmd/testram
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./cmd/testram/testram-linux-arm64 ./cmd/testram
 
 build:
 	go build -o ./cmd/web/web ./cmd/web
@@ -17,11 +22,11 @@ build:
 	go build -o ./cmd/testram/testram ./cmd/testram
 
 builddocker:
-	docker build -t lanecwagner/synergychat-web ./cmd/web
-	docker build -t lanecwagner/synergychat-api ./cmd/api
-	docker build -t lanecwagner/synergychat-crawler ./cmd/crawler
-	docker build -t lanecwagner/synergychat-testram ./cmd/testram
-	docker build -t lanecwagner/synergychat-testcpu ./cmd/testcpu
+	docker buildx build --platform=linux/amd64,linux/arm64 -t lanecwagner/synergychat-web ./cmd/web
+	docker buildx build --platform=linux/amd64,linux/arm64 -t lanecwagner/synergychat-api ./cmd/api
+	docker buildx build --platform=linux/amd64,linux/arm64 -t lanecwagner/synergychat-crawler ./cmd/crawler
+	docker buildx build --platform=linux/amd64,linux/arm64 -t lanecwagner/synergychat-testram ./cmd/testram
+	docker buildx build --platform=linux/amd64,linux/arm64 -t lanecwagner/synergychat-testcpu ./cmd/testcpu
 
 pushdocker:
 	docker push lanecwagner/synergychat-web

--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -1,8 +1,10 @@
-FROM --platform=linux/amd64 debian:stable-slim
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 RUN apt-get upgrade -y
 
-ADD api /bin/api
+ARG TARGETOS
+ARG TARGETARCH
+ADD api-${TARGETOS}-${TARGETARCH} /bin/api
 
 CMD ["/bin/api"]

--- a/cmd/crawler/Dockerfile
+++ b/cmd/crawler/Dockerfile
@@ -1,8 +1,10 @@
-FROM --platform=linux/amd64 debian:stable-slim
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 RUN apt-get upgrade -y
 
-ADD crawler /bin/crawler
+ARG TARGETOS
+ARG TARGETARCH
+ADD crawler-${TARGETOS}-${TARGETARCH} /bin/crawler
 
 CMD ["/bin/crawler"]

--- a/cmd/testcpu/Dockerfile
+++ b/cmd/testcpu/Dockerfile
@@ -1,5 +1,7 @@
-FROM --platform=linux/amd64 scratch
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
-ADD testcpu /bin/testcpu
+ARG TARGETOS
+ARG TARGETARCH
+ADD testcpu-${TARGETOS}-${TARGETARCH} /bin/testcpu
 
 CMD ["/bin/testcpu"]

--- a/cmd/testcpu/Dockerfile
+++ b/cmd/testcpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM debian:stable-slim
+FROM --platform=$TARGETPLATFORM scratch
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/testram/Dockerfile
+++ b/cmd/testram/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM debian:stable-slim
+FROM --platform=$TARGETPLATFORM scratch
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cmd/testram/Dockerfile
+++ b/cmd/testram/Dockerfile
@@ -1,5 +1,7 @@
-FROM --platform=linux/amd64 scratch
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
-ADD testram /bin/testram
+ARG TARGETOS
+ARG TARGETARCH
+ADD testram-${TARGETOS}-${TARGETARCH} /bin/testram
 
 CMD ["/bin/testram"]

--- a/cmd/web/Dockerfile
+++ b/cmd/web/Dockerfile
@@ -1,8 +1,10 @@
-FROM --platform=linux/amd64 debian:stable-slim
+FROM --platform=$TARGETPLATFORM debian:stable-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 RUN apt-get upgrade -y
 
-ADD web /bin/web
+ARG TARGETOS
+ARG TARGETARCH
+ADD web-${TARGETOS}-${TARGETARCH} /bin/web
 
 CMD ["/bin/web"]


### PR DESCRIPTION
I changed the MakeFile and Dockerfiles to build images for both linux/amd64 and linux/arm64.

Must enable "containerd" in Docker Desktop settings to build multiple platform images. Then run: 

`docker buildx build --platform=linux/amd64,linux/arm64 -t <image>`

<img width="823" alt="Screenshot 2024-02-17 at 6 06 07 PM" src="https://github.com/bootdotdev/synergychat/assets/59619403/d8ba13c0-2e51-4c7c-a4d5-2ca34b5317d0">
